### PR TITLE
Reading preprocessed JPK files

### DIFF
--- a/PyFMReader_DyNaMo/src/pyfmreader/jpk/loadjpkcurve.py
+++ b/PyFMReader_DyNaMo/src/pyfmreader/jpk/loadjpkcurve.py
@@ -53,6 +53,9 @@ def loadJPKcurve(paths, afm_file, curve_index, file_metadata):
                 elif 'short' in conversion_factors["encoder_type"]:
                     divider = 2
                     format_id = 'h'
+                elif 'float' in conversion_factors["encoder_type"]:
+                    divider = 4
+                    format_id = 'f'
                 nbr_points = afm_file.getinfo(path).file_size // divider
                 filecontents = afm_file.read(path)
                 data_raw = unpack(f">{str(nbr_points)}{format_id}", filecontents)

--- a/PyFMReader_DyNaMo/src/pyfmreader/jpk/parsejpkheader.py
+++ b/PyFMReader_DyNaMo/src/pyfmreader/jpk/parsejpkheader.py
@@ -107,11 +107,8 @@ def parseJPKheader(filepath, header_properties, shared_data_properties, filesuff
             properties["encoder_type"] = shared_data_properties.get(pre + ".encoder.type")
             if properties["encoder_type"] is None: # Use higher-level data type descriptor and assume no decoding needs to be done
                 properties["encoder_type"] = shared_data_properties.get(pre + ".type")
-                properties["encoder_offet_key"] = 0.0
-                properties["encoder_multiplier_key"] = 1.0
-            else:
-                properties["encoder_offet_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.offset", offset_default))
-                properties["encoder_multiplier_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.multiplier", multiplier_default))
+            properties["encoder_offet_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.offset", offset_default))
+            properties["encoder_multiplier_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.multiplier", multiplier_default))
 
             properties["base"] = shared_data_properties.get(pre_conv + ".conversions.base")
             
@@ -151,11 +148,8 @@ def parseJPKheader(filepath, header_properties, shared_data_properties, filesuff
             properties["encoder_type"] = shared_data_properties.get(pre + ".encoder.type")
             if properties["encoder_type"] is None: # Use higher-level data type descriptor and assume no decoding needs to be done
                 properties["encoder_type"] = shared_data_properties.get(pre + ".type")
-                properties["encoder_offet_key"] = 0.0
-                properties["encoder_multiplier_key"] = 1.0
-            else:
-                properties["encoder_offet_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.offset", offset_default))
-                properties["encoder_multiplier_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.multiplier", scaling_factor))
+            properties["encoder_offet_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.offset", offset_default))
+            properties["encoder_multiplier_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.multiplier", scaling_factor))
             
             properties["base"] = shared_data_properties.get(pre_conv + ".conversions.base")
 

--- a/PyFMReader_DyNaMo/src/pyfmreader/jpk/parsejpkheader.py
+++ b/PyFMReader_DyNaMo/src/pyfmreader/jpk/parsejpkheader.py
@@ -45,10 +45,6 @@ def parseJPKheader(filepath, header_properties, shared_data_properties, filesuff
         prefix = "quantitative-imaging-map"
         file_metadata['force_volume'] = 1
         pre_header = ".settings"
-    elif file_metadata["file_type"] == "jpk-qi-series":
-        prefix = "quantitative-imaging-series"
-        file_metadata['force_volume'] = 0
-        pre_header = ".header"
     elif file_metadata["file_type"] == "jpk-force":
         prefix = "force-scan-series"
         pre_header = ".header"
@@ -109,8 +105,13 @@ def parseJPKheader(filepath, header_properties, shared_data_properties, filesuff
 
         if channel_name in ("vDeflection", "hDeflection"):
             properties["encoder_type"] = shared_data_properties.get(pre + ".encoder.type")
-            properties["encoder_offet_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.offset", offset_default))
-            properties["encoder_multiplier_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.multiplier", multiplier_default))
+            if properties["encoder_type"] is None: # Use higher-level data type descriptor and assume no decoding needs to be done
+                properties["encoder_type"] = shared_data_properties.get(pre + ".type")
+                properties["encoder_offet_key"] = 0.0
+                properties["encoder_multiplier_key"] = 1.0
+            else:
+                properties["encoder_offet_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.offset", offset_default))
+                properties["encoder_multiplier_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.multiplier", multiplier_default))
 
             properties["base"] = shared_data_properties.get(pre_conv + ".conversions.base")
             
@@ -148,8 +149,13 @@ def parseJPKheader(filepath, header_properties, shared_data_properties, filesuff
         
         elif channel_name in ("capacitiveSensorHeight", "measuredHeight", "height", "cellhesion-height", "strainGaugeHeight"):
             properties["encoder_type"] = shared_data_properties.get(pre + ".encoder.type")
-            properties["encoder_offet_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.offset", offset_default))
-            properties["encoder_multiplier_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.multiplier", scaling_factor))
+            if properties["encoder_type"] is None: # Use higher-level data type descriptor and assume no decoding needs to be done
+                properties["encoder_type"] = shared_data_properties.get(pre + ".type")
+                properties["encoder_offet_key"] = 0.0
+                properties["encoder_multiplier_key"] = 1.0
+            else:
+                properties["encoder_offet_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.offset", offset_default))
+                properties["encoder_multiplier_key"] = float(shared_data_properties.get(pre + ".encoder.scaling.multiplier", scaling_factor))
             
             properties["base"] = shared_data_properties.get(pre_conv + ".conversions.base")
 
@@ -222,7 +228,7 @@ def parseJPKsegmentheader(curve_properties, curve_index, file_type, segment_head
         segment_metadata["baseline_measured"] = False
     segment_metadata["baseline"] = float(segment_header.get("force-segment-header.baseline.baseline", offset_default))
 
-    if file_type in ("jpk-force", "jpk-qi-series"):
+    if file_type == "jpk-force":
         segment_metadata["approach_id"] = segment_header.get("force-segment-header.approach-id")
         segment_metadata["style"] = segment_header.get("force-segment-header.settings.style")
 

--- a/PyFMReader_DyNaMo/src/pyfmreader/utils/forcecurve.py
+++ b/PyFMReader_DyNaMo/src/pyfmreader/utils/forcecurve.py
@@ -106,3 +106,21 @@ class ForceCurve:
         """
         for _, segment in self.get_segments():
             segment.get_force_vs_indentation(poc, spring_constant)
+
+    def get_force_vs_indentation_precal(self, spring_constant):
+        """
+        Computes force vs indentation curve from deflection and piezo_height and populates
+        the indentation and force properties. Does not perform correction of the z height by the cantilever position, 
+        as it assumes this has already been done elsewhere. Assumes piezo_height and deflection are centered around the poc.
+
+        Indentation = piezo_height(m)
+        Force = Kc(N/m) * deflection(m)
+
+                Parameters:
+                        spring_constant (float): in N/m
+                
+                Returns: None
+        """
+
+        for _, segment in self.get_segments():
+            segment.get_force_vs_indentation_precal(spring_constant)

--- a/PyFMReader_DyNaMo/src/pyfmreader/utils/segment.py
+++ b/PyFMReader_DyNaMo/src/pyfmreader/utils/segment.py
@@ -88,11 +88,11 @@ class Segment:
                 Returns: None
         """
         deflection_v = self.segment_formated_data["vDeflection"]
-        if self.segment_metadata is not None and\
+        if y0 is not None: # This condition needs to be first to allow user to overwrite metadata based processing
+            deflection_v = deflection_v - y0
+        elif self.segment_metadata is not None and\
             self.segment_metadata["baseline_measured"]:
             deflection_v = deflection_v - self.segment_metadata["baseline"]
-        elif y0 is not None:
-            deflection_v = deflection_v - y0
         self.vdeflection = deflection_v * deflection_sens
         self.zheight = self.segment_formated_data[height_channel_key]
         if "time" in self.segment_formated_data:

--- a/PyFMReader_DyNaMo/src/pyfmreader/utils/segment.py
+++ b/PyFMReader_DyNaMo/src/pyfmreader/utils/segment.py
@@ -125,3 +125,23 @@ class Segment:
         # Force = Kc(N/m) * deflection(m)
         self.indentation = np.array(self.zheight - self.vdeflection - center_force_x)
         self.force = np.array(self.vdeflection * spring_constant - center_force_y)
+
+    def get_force_vs_indentation_precal(self, spring_constant):
+        """
+        Computes force vs indentation curve from deflection and piezo_height and populates
+        the indentation and force properties. Does not perform correction of the z height by the cantilever position, 
+        as it assumes this has already been done elsewhere. Assumes piezo_height and deflection are centered around the poc.
+
+        Indentation = piezo_height(m)
+        Force = Kc(N/m) * deflection(m)
+
+                Parameters:
+                        spring_constant (float): in N/m
+                
+                Returns: None
+        """
+
+        # Indentation = piezo_height(m)
+        # Force = Kc(N/m) * deflection(m)
+        self.indentation = np.array(self.zheight)
+        self.force = np.array(self.vdeflection * spring_constant)


### PR DESCRIPTION
AFM force curve data already preprocessed in JPK DP populate the vDeflection entry with float type data. 
- Added the functionality, if encoder metadata are missing in a channel's metadata, to set the datatype by the channel's type. This allows to load float data.
- Adjusted HertzFit params so preprocessing can be optional. 
        'correct_baseline': False,         # Perform baseline correction, tilt, offset, or False
- Added get_force_vs_indentation_precal function to segment and forcecurve class, which does not include tip deflection correction for the height. 